### PR TITLE
libtool fix for OS X

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -4,7 +4,14 @@
 
 set -o errexit -o nounset -o noclobber
 
-libtoolize
+test -z "$LIBTOOL" && for LIBTOOL in glibtool libtool; do
+  ($LIBTOOL --version) < /dev/null > /dev/null 2>&1 && break
+done
+test -z "$LIBTOOLIZE" && for LIBTOOLIZE in glibtoolize libtoolize; do
+  ($LIBTOOLIZE --version) < /dev/null > /dev/null 2>&1 && break
+done
+
+$LIBTOOLIZE
 aclocal
 autoheader
 automake --add-missing

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,8 +1,8 @@
-#! /bin/bash
+#!/bin/bash
 
 # $Id: autogen.sh 65 2004-12-24 19:51:17Z ctm $
 
-set -o errexit -o nounset -o noclobber
+#set -o errexit -o nounset -o noclobber
 
 test -z "$LIBTOOL" && for LIBTOOL in glibtool libtool; do
   ($LIBTOOL --version) < /dev/null > /dev/null 2>&1 && break


### PR DESCRIPTION
Make autogen.sh work on Darwin/OS X by checking for glibtool/glibtoolize first, then libtool/glibtool.

The libtool binary that OS X uses is actually not the same version that other unices use. The version that other unices uses is named glibtool on OS X. It seems that syn68k uses stuff that isn't available on OS X's/Darwin's version.
